### PR TITLE
Upgraded sbt-nexus-workbench to 0.1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val prov = project
     moduleName := "nexus-prov",
     resolvers += Resolver.bintrayRepo("bogdanromanx", "maven"),
     autoScalaLibrary := false,
-    workbenchVersion := "0.1.3"
+    workbenchVersion := "0.1.4"
   )
 
 lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("ch.epfl.bluebrain.nexus" % "sbt-nexus"           % "0.4.1")
-addSbtPlugin("ch.epfl.bluebrain.nexus" % "sbt-nexus-workbench" % "0.1.3")
+addSbtPlugin("ch.epfl.bluebrain.nexus" % "sbt-nexus-workbench" % "0.1.4")


### PR DESCRIPTION
The changes in the new version fixes an issue with the test
execution where the compiled test class is lost when the
generation is skipped.